### PR TITLE
Xen 48

### DIFF
--- a/SOURCES/xen-queue.am
+++ b/SOURCES/xen-queue.am
@@ -508,3 +508,50 @@ index bd974fb13d..da54f10df3 100644
  #define PSR_MODE_EL3t 0x0c
 -- 
 
+From dd448f732978efbff0d6f4c79661c9b64d557866 Mon Sep 17 00:00:00 2001
+From: George Dunlap <george.dunlap@citrix.com>
+Date: Tue, 7 Jun 2016 11:23:02 +0100
+Subject: [PATCH] libxc: Try /proc/xen/privcmd on EACCES as well
+
+/proc/xen/privcmd is deprecated in favor of /dev/xen/privcmd; but at
+the moment the SELinux rules in CentOS 7 are outdated and only know
+about /proc; access to the /dev node will result in EACCES.
+
+As a temporary work-around, try to read the /proc path if opening the /dev
+path fails with EACCES.
+
+Signed-off-by: George Dunlap <george.dunlap@citrix.com>
+---
+ tools/libs/call/linux.c          | 2 +-
+ tools/libs/foreignmemory/linux.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/call/linux.c b/tools/libs/call/linux.c
+index e8e0311..36572e9 100644
+--- a/tools/libs/call/linux.c
++++ b/tools/libs/call/linux.c
+@@ -39,7 +39,7 @@ int osdep_xencall_open(xencall_handle *xcall)
+      */
+     fd = open("/dev/xen/privcmd", O_RDWR|O_CLOEXEC);
+ 
+-    if ( fd == -1 && ( errno == ENOENT || errno == ENXIO || errno == ENODEV ))
++    if ( fd == -1 && ( errno == ENOENT || errno == ENXIO || errno == ENODEV || errno == EACCES ))
+     {
+         /* Fallback to /proc/xen/privcmd */
+         fd = open("/proc/xen/privcmd", O_RDWR|O_CLOEXEC);
+diff --git a/tools/libs/foreignmemory/linux.c b/tools/libs/foreignmemory/linux.c
+index 423c744..72e4b07 100644
+--- a/tools/libs/foreignmemory/linux.c
++++ b/tools/libs/foreignmemory/linux.c
+@@ -41,7 +41,7 @@ int osdep_xenforeignmemory_open(xenforeignmemory_handle *fmem)
+     /* prefer this newer interface */
+     fd = open("/dev/xen/privcmd", O_RDWR|O_CLOEXEC);
+ 
+-    if ( fd == -1 && ( errno == ENOENT || errno == ENXIO || errno == ENODEV ))
++    if ( fd == -1 && ( errno == ENOENT || errno == ENXIO || errno == ENODEV || errno == EACCES ))
+     {
+         /* Fallback to /proc/xen/privcmd */
+         fd = open("/proc/xen/privcmd", O_RDWR|O_CLOEXEC);
+-- 
+1.9.1
+

--- a/SOURCES/xen-queue.am
+++ b/SOURCES/xen-queue.am
@@ -555,3 +555,251 @@ index 423c744..72e4b07 100644
 -- 
 1.9.1
 
+From 804cd4977020906b278743050d12d93a29626075 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 9 Jun 2017 21:29:06 -0700
+Subject: [PATCH 1/2] multicall: deal with early exit conditions
+
+In particular changes to guest privilege level require the multicall
+sequence to be aborted, as hypercalls are permitted from kernel mode
+only. While likely not very useful in a multicall, also properly handle
+the return value in the HYPERVISOR_iret case (which should be the guest
+specified value).
+
+This is XSA-213.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Acked-by: Julien Grall <julien.grall@arm.com>
+---
+ xen/arch/arm/traps.c        | 11 +++++++----
+ xen/arch/x86/hypercall.c    | 26 ++++++++++++++++++--------
+ xen/common/multicall.c      | 17 ++++++++++++++---
+ xen/include/xen/multicall.h |  6 +++++-
+ 4 files changed, 44 insertions(+), 16 deletions(-)
+
+diff --git a/xen/arch/arm/traps.c b/xen/arch/arm/traps.c
+index 90aba2a..0f3ef1f 100644
+--- a/xen/arch/arm/traps.c
++++ b/xen/arch/arm/traps.c
+@@ -1531,7 +1531,7 @@ static bool_t check_multicall_32bit_clean(struct multicall_entry *multi)
+     return true;
+ }
+ 
+-void arch_do_multicall_call(struct mc_state *state)
++enum mc_disposition arch_do_multicall_call(struct mc_state *state)
+ {
+     struct multicall_entry *multi = &state->call;
+     arm_hypercall_fn_t call = NULL;
+@@ -1539,23 +1539,26 @@ void arch_do_multicall_call(struct mc_state *state)
+     if ( multi->op >= ARRAY_SIZE(arm_hypercall_table) )
+     {
+         multi->result = -ENOSYS;
+-        return;
++        return mc_continue;
+     }
+ 
+     call = arm_hypercall_table[multi->op].fn;
+     if ( call == NULL )
+     {
+         multi->result = -ENOSYS;
+-        return;
++        return mc_continue;
+     }
+ 
+     if ( is_32bit_domain(current->domain) &&
+          !check_multicall_32bit_clean(multi) )
+-        return;
++        return mc_continue;
+ 
+     multi->result = call(multi->args[0], multi->args[1],
+                          multi->args[2], multi->args[3],
+                          multi->args[4]);
++
++    return likely(!psr_mode_is_user(guest_cpu_user_regs()))
++           ? mc_continue : mc_preempt;
+ }
+ 
+ /*
+diff --git a/xen/arch/x86/hypercall.c b/xen/arch/x86/hypercall.c
+index d2b5331..3023041 100644
+--- a/xen/arch/x86/hypercall.c
++++ b/xen/arch/x86/hypercall.c
+@@ -255,15 +255,19 @@ void pv_hypercall(struct cpu_user_regs *regs)
+     perfc_incr(hypercalls);
+ }
+ 
+-void arch_do_multicall_call(struct mc_state *state)
++enum mc_disposition arch_do_multicall_call(struct mc_state *state)
+ {
+-    if ( !is_pv_32bit_vcpu(current) )
++    struct vcpu *curr = current;
++    unsigned long op;
++
++    if ( !is_pv_32bit_vcpu(curr) )
+     {
+         struct multicall_entry *call = &state->call;
+ 
+-        if ( (call->op < ARRAY_SIZE(pv_hypercall_table)) &&
+-             pv_hypercall_table[call->op].native )
+-            call->result = pv_hypercall_table[call->op].native(
++        op = call->op;
++        if ( (op < ARRAY_SIZE(pv_hypercall_table)) &&
++             pv_hypercall_table[op].native )
++            call->result = pv_hypercall_table[op].native(
+                 call->args[0], call->args[1], call->args[2],
+                 call->args[3], call->args[4], call->args[5]);
+         else
+@@ -274,15 +278,21 @@ void arch_do_multicall_call(struct mc_state *state)
+     {
+         struct compat_multicall_entry *call = &state->compat_call;
+ 
+-        if ( (call->op < ARRAY_SIZE(pv_hypercall_table)) &&
+-             pv_hypercall_table[call->op].compat )
+-            call->result = pv_hypercall_table[call->op].compat(
++        op = call->op;
++        if ( (op < ARRAY_SIZE(pv_hypercall_table)) &&
++             pv_hypercall_table[op].compat )
++            call->result = pv_hypercall_table[op].compat(
+                 call->args[0], call->args[1], call->args[2],
+                 call->args[3], call->args[4], call->args[5]);
+         else
+             call->result = -ENOSYS;
+     }
+ #endif
++
++    return unlikely(op == __HYPERVISOR_iret)
++           ? mc_exit
++           : likely(guest_kernel_mode(curr, guest_cpu_user_regs()))
++             ? mc_continue : mc_preempt;
+ }
+ 
+ /*
+diff --git a/xen/common/multicall.c b/xen/common/multicall.c
+index 524c9bf..5d25376 100644
+--- a/xen/common/multicall.c
++++ b/xen/common/multicall.c
+@@ -40,6 +40,7 @@ do_multicall(
+     struct mc_state *mcs = &current->mc_state;
+     uint32_t         i;
+     int              rc = 0;
++    enum mc_disposition disp = mc_continue;
+ 
+     if ( unlikely(__test_and_set_bit(_MCSF_in_multicall, &mcs->flags)) )
+     {
+@@ -50,7 +51,7 @@ do_multicall(
+     if ( unlikely(!guest_handle_okay(call_list, nr_calls)) )
+         rc = -EFAULT;
+ 
+-    for ( i = 0; !rc && i < nr_calls; i++ )
++    for ( i = 0; !rc && disp == mc_continue && i < nr_calls; i++ )
+     {
+         if ( i && hypercall_preempt_check() )
+             goto preempted;
+@@ -63,7 +64,7 @@ do_multicall(
+ 
+         trace_multicall_call(&mcs->call);
+ 
+-        arch_do_multicall_call(mcs);
++        disp = arch_do_multicall_call(mcs);
+ 
+ #ifndef NDEBUG
+         {
+@@ -77,7 +78,14 @@ do_multicall(
+         }
+ #endif
+ 
+-        if ( unlikely(__copy_field_to_guest(call_list, &mcs->call, result)) )
++        if ( unlikely(disp == mc_exit) )
++        {
++            if ( __copy_field_to_guest(call_list, &mcs->call, result) )
++                /* nothing, best effort only */;
++            rc = mcs->call.result;
++        }
++        else if ( unlikely(__copy_field_to_guest(call_list, &mcs->call,
++                                                 result)) )
+             rc = -EFAULT;
+         else if ( mcs->flags & MCSF_call_preempted )
+         {
+@@ -93,6 +101,9 @@ do_multicall(
+             guest_handle_add_offset(call_list, 1);
+     }
+ 
++    if ( unlikely(disp == mc_preempt) && i < nr_calls )
++        goto preempted;
++
+     perfc_incr(calls_to_multicall);
+     perfc_add(calls_from_multicall, i);
+     mcs->flags = 0;
+diff --git a/xen/include/xen/multicall.h b/xen/include/xen/multicall.h
+index fff15eb..75e2cc5 100644
+--- a/xen/include/xen/multicall.h
++++ b/xen/include/xen/multicall.h
+@@ -24,6 +24,10 @@ struct mc_state {
+     };
+ };
+ 
+-void arch_do_multicall_call(struct mc_state *mc);
++enum mc_disposition {
++    mc_continue,
++    mc_exit,
++    mc_preempt,
++} arch_do_multicall_call(struct mc_state *mc);
+ 
+ #endif /* __XEN_MULTICALL_H__ */
+-- 
+1.9.1
+
+
+From d5ce6b4410779ea6a99cc2520dff890896bd7012 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 9 Jun 2017 21:29:10 -0700
+Subject: [PATCH 2/2] x86: discard type information when stealing pages
+
+While a page having just a single general reference left necessarily
+has a zero type reference count too, its type may still be valid (and
+in validated state; at present this is only possible and relevant for
+PGT_seg_desc_page, as page tables have their type forcibly zapped when
+their type reference count drops to zero, and
+PGT_{writable,shared}_page pages don't require any validation). In
+such a case when the page is being re-used with the same type again,
+validation is being skipped. As validation criteria differ between
+32- and 64-bit guests, pages to be transferred between guests need to
+have their validation indicator zapped (and with it we zap all other
+type information at once).
+
+This is XSA-214.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+---
+ xen/arch/x86/mm.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/xen/arch/x86/mm.c b/xen/arch/x86/mm.c
+index 03dcd71..20e94f7 100644
+--- a/xen/arch/x86/mm.c
++++ b/xen/arch/x86/mm.c
+@@ -4422,6 +4422,17 @@ int steal_page(
+         y = cmpxchg(&page->count_info, x, x & ~PGC_count_mask);
+     } while ( y != x );
+ 
++    /*
++     * With the sole reference dropped temporarily, no-one can update type
++     * information. Type count also needs to be zero in this case, but e.g.
++     * PGT_seg_desc_page may still have PGT_validated set, which we need to
++     * clear before transferring ownership (as validation criteria vary
++     * depending on domain type).
++     */
++    BUG_ON(page->u.inuse.type_info & (PGT_count_mask | PGT_locked |
++                                      PGT_pinned));
++    page->u.inuse.type_info = 0;
++
+     /* Swizzle the owner then reinstate the PGC_allocated reference. */
+     page_set_owner(page, NULL);
+     y = page->count_info;
+-- 
+1.9.1
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -379,7 +379,7 @@ export GIT=$(type -P false)
 
 %define extra_config %{?extra_config_systemd} %{?extra_config_blktap} %{?extra_config_arch} %{?extra_config_spice}
 
-WGET=/bin/false ./configure --prefix=/usr --libexecdir=%{_libexecdir} --libdir=%{_libdir} --with-xenstored=xenstored %{?extra_config}
+WGET=/bin/false ./configure --prefix=/usr --libexecdir=%{_libexecdir} --libdir=%{_libdir} --with-xenstored=xenstored --disable-xsmpolicy %{?extra_config}
 
 export EFI_VENDOR="%{xen_efi_vendor}"
 make %{?_smp_mflags} %{?efi_flags}   dist-xen

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -80,6 +80,10 @@ Source51: xen-kernel.aarch64
 Source52: efi-xen.cfg.aarch64
 Source53: edk2-bc54e50e0fe03c570014f363b547426913e92449.tar.gz
 
+%if %{with_livepatch}
+Source60: livepatch-tools-2af6f1aa62334f8c3d66cf2c5043686833de6cc6.tar.gz
+%endif
+
 Source101: blktap-d73c74874a449c18dc1528076e5c0671cc5ed409.tar.gz
 
 Patch1: xen-queue.am
@@ -149,6 +153,9 @@ BuildRequires: ocaml, ocaml-findlib
 %endif
 %if %with_spice
 BuildRequires: spice-server-devel usbredir-devel
+%endif
+%if %with_livepatch
+BuildRequires: elfutils-libelf-devel
 %endif
 # efi image needs an ld that has -mi386pep option
 %if %build_efi
@@ -254,6 +261,23 @@ This package contains libraries for developing ocaml tools to
 manage Xen virtual machines.
 %endif
 
+%if %with_livepatch
+%package livepatch-build-tools
+Summary: Tools to build Xen live patches
+Group: Development/Libraries
+Requires: elfutils
+Requires: make
+Requires: perl
+Requires: sed
+Requires: coreutils
+Requires: grep
+Requires: patch
+Requires: gcc
+
+%description livepatch-build-tools
+This package contains the tools needed for generating live patches
+per https://wiki.xen.org/wiki/LivePatch .
+%endif
 
 %prep
 %setup -q
@@ -306,6 +330,7 @@ git am %{PATCH1}
 #Optionally enable live patching
 %if %{with_livepatch}
 echo "CONFIG_LIVEPATCH=y" > xen/.config
+%{__tar} -C ${RPM_BUILD_DIR}/%{name}-%{version}/tools/ -zxf %{SOURCE60}
 %endif
 
 make -C xen olddefconfig
@@ -415,6 +440,13 @@ echo "No tianocore available" && false
 %endif
 %endif
 
+%if %{with_livepatch}
+pushd `pwd`
+cd tools/livepatch-build-tools
+make
+popd
+%endif
+
 %install
 rm -rf %{buildroot}
 %if %build_ocaml
@@ -446,6 +478,13 @@ install -D -m 644 tools/edk2/Build/ArmVirtXen-AARCH64/RELEASE_GCC48/FV/XEN_EFI.f
 
 %ifarch x86_64
 install -m 644 %{SOURCE50} $RPM_BUILD_ROOT/etc/sysconfig/xen-kernel
+%endif
+
+%if %{with_livepatch}
+pushd `pwd`
+cd tools/livepatch-build-tools
+make DESTDIR=%{buildroot} PREFIX=/usr install
+popd
 %endif
 
 %ifarch aarch64
@@ -906,6 +945,16 @@ rm -rf %{buildroot}
 %{_libdir}/ocaml/xen*/*.a
 %{_libdir}/ocaml/xen*/*.cmxa
 %{_libdir}/ocaml/xen*/*.cmx
+%endif
+
+%if %with_livepatch
+%files livepatch-build-tools
+%defattr(-,root,root)
+%{_bindir}/livepatch-build
+%dir /usr/libexec/livepatch-build-tools
+/usr/libexec/livepatch-build-tools/prelink
+/usr/libexec/livepatch-build-tools/create-diff-object
+/usr/libexec/livepatch-build-tools/livepatch-gcc
 %endif
 
 %changelog

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -8,6 +8,10 @@
 # --without efi
 %define build_efi %{?_without_efi: 0} %{?!_without_efi: 1}
 
+# build with live patching enabled unless rpmbuild was run with
+# --without livepatch
+%define with_livepatch %{?_without_livepatch: 0} %{?!_without_livepatch: 1}
+
 %if 0%{?centos_ver} == 6
 %define with_sysv 1
 %define with_systemd 0
@@ -298,6 +302,13 @@ git commit -a -q -m "%{version} baseline."
 
 # Apply patches to code in the core Xen repo
 git am %{PATCH1}
+
+#Optionally enable live patching
+%if %{with_livepatch}
+echo "CONFIG_LIVEPATCH=y" > xen/.config
+%endif
+
+make -C xen olddefconfig
 
 # Now apply patches to things not in the core Xen repo
 

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -56,7 +56,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.8.1
-Release: 1%{?dist}
+Release: 4%{?dist}
 Group:   Development/Libraries
 License: GPLv2+ and LGPLv2+ and BSD
 URL:     https://www.xenproject.org/
@@ -958,6 +958,16 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
+* Tue Jun 13 2017 Sarah Newman <srn@prgmr.com> 4.8.1-4.el6.centos
+- Bump version due to disabling xsmflash
+
+* Tue Jun 13 2017 Sarah Newman <srn@prgmr.com> 4.8.1-3.el6.centos
+- unused build number
+
+* Fri Jun 09 2017 Sarah Newman <srn@prgmr.com> 4.8.1-2.el6.centos
+- Import XSAs 213-214 (XSA 215 does not apply)
+- Enable live patching by default
+
 * Thu Apr 27 2017 Anthony Perard <anthony.perard@citrix.com> 4.8.1-1.el6.centos
 - Update to Xen 4.8.1
 

--- a/get_sources.sh
+++ b/get_sources.sh
@@ -47,6 +47,19 @@ if [[ ! -e SOURCES/$EDK2_FILE ]] ; then
     popd
 fi
 
+echo "Checking livepatch-build-tools..."
+if [[ ! -e SOURCES/$LIVEPATCH_FILE ]] ; then
+    echo "Cloning livepatch-build-tools repo..."
+    mkdir -p git-tmp
+    pushd git-tmp
+
+    git clone $LIVEPATCH_URL livepatch-build-tools.git || exit 1
+    cd livepatch-build-tools.git
+    echo "Creating $LIVEPATCH_FILE..."
+    git archive --prefix=livepatch-build-tools/ -o ../../SOURCES/$LIVEPATCH_FILE $LIVEPATCH_CSET || exit 1
+    popd
+fi
+
 if [[ -e git-tmp ]] ; then
     echo "Cleaning up cloned repositores"
     rm -rf git-tmp

--- a/sources.cfg
+++ b/sources.cfg
@@ -1,9 +1,10 @@
-XEN_VERSION=4.6.4
+XEN_VERSION=4.8.1
 XEN_URL=git://xenbits.xenproject.org/xen.git
-XEN_RELEASE_BASE=http://bits.xensource.com/oss-xen/release/
+XEN_RELEASE_BASE=https://downloads.xenproject.org/release/xen/
 XEN_RELEASE_FILE=xen-$XEN_VERSION.tar.gz
+XEN_KEY=83FE14C957E82BD9
 
-XEN_EXTLIB_URL=http://xenbits.xen.org/xen-extfiles
+XEN_EXTLIB_URL=https://xenbits.xen.org/xen-extfiles
 XEN_EXTLIB_FILES="grub-0.97.tar.gz \
 	     lwip-1.3.0.tar.gz \
 	     newlib-1.16.0.tar.gz \
@@ -16,5 +17,5 @@ BLKTAP_CSET=d73c74874a449c18dc1528076e5c0671cc5ed409
 BLKTAP_FILE=blktap-$BLKTAP_CSET.tar.gz
 
 EDK2_URL=https://github.com/tianocore/edk2.git
-EDK2_CSET=0cebfe81f94be36116af66d0a3134ce18d89eec1
+EDK2_CSET=bc54e50e0fe03c570014f363b547426913e92449
 EDK2_FILE=edk2-$EDK2_CSET.tar.gz

--- a/sources.cfg
+++ b/sources.cfg
@@ -19,3 +19,7 @@ BLKTAP_FILE=blktap-$BLKTAP_CSET.tar.gz
 EDK2_URL=https://github.com/tianocore/edk2.git
 EDK2_CSET=bc54e50e0fe03c570014f363b547426913e92449
 EDK2_FILE=edk2-$EDK2_CSET.tar.gz
+
+LIVEPATCH_URL=git://xenbits.xen.org/livepatch-build-tools.git
+LIVEPATCH_CSET=0c104573a1c168995ec553778d1d2d1ebe9c9042
+LIVEPATCH_FILE=livepatch-tools-$LIVEPATCH_CSET.tar.gz


### PR DESCRIPTION
This appears to work with selinux on and centos 6. After installing xen-debuginfo, I built a patch for xsa214 from rpmbuild/BUILD/xen-4.8.1 using:

/usr/bin/livepatch-build -s . -c xen/.config -p ~/xsa214.patch -o xsa214 --xen-syms /usr/lib/debug/xen-syms-4.8.1-1.el6 --depends $(eu-readelf -n /usr/lib/debug/xen-syms-4.8.1-1.el6 | tail -1 | sed 's/.*Build ID: //')

The instructions on https://wiki.xen.org/wiki/LivePatch for uploading and applying the patch appeared to work:

$ sudo xl info | grep build_id
build_id : b249a7b99119d45e743846980f5895f9adb15edc

$ sudo /usr/sbin/xen-livepatch upload xsa214 xsa214.livepatch
Uploading xsa214.livepatch (523280 bytes)
$ sudo /usr/sbin/xen-livepatch list
ID | status
----------------------------------------+------------
xsa214 | CHECKED

$ sudo xl dmesg | tail -15
(XEN) 'x' pressed - Dumping all livepatch patches
(XEN) build-id: b249a7b99119d45e743846980f5895f9adb15edc
(XEN) name=xsa214 state=CHECKED(1) ffff82d080409000 (.data=ffff82d08040a000, .rodata=ffff82d08040a000) using 2 pages.
(XEN) steal_page patch ffff82d08017d820(528) with ffff82d0804090d0 (565)
(XEN) build-id=6bf60663b32d6767270a75e3a8816ad5f1fe5836
(XEN) depend-on=b249a7b99119d45e743846980f5895f9adb15edc

$ sudo /usr/sbin/xen-livepatch apply xsa214
Performing apply:. completed
$ sudo /usr/sbin/xen-livepatch list
ID | status
----------------------------------------+------------
xsa214 | APPLIED